### PR TITLE
Remove probe action prefix on log and trace point snapshot ids

### DIFF
--- a/packages/sidekick-agent-nodejs/src/api/internal/debug/logpoint/LogPointAction.ts
+++ b/packages/sidekick-agent-nodejs/src/api/internal/debug/logpoint/LogPointAction.ts
@@ -131,7 +131,7 @@ export default class LogPointAction extends CaptureProbeAction<LogPointContext> 
       } = this.context.getProbe();
   
       const logPointEvent = new LogPointEvent(
-        id,
+        id.replace(`${this.context.rawProbe.action}:`, ''),
         client,
         remoteFilename || fileName,
         frame.methodName,

--- a/packages/sidekick-agent-nodejs/src/api/internal/debug/tracepoint/TracePointAction.ts
+++ b/packages/sidekick-agent-nodejs/src/api/internal/debug/tracepoint/TracePointAction.ts
@@ -47,7 +47,7 @@ export default class TracePointAction extends CaptureProbeAction<TracePointConte
 
         const convertedFrames = this.captureFrameConverter.convert(userFrames);
         const snapshotEvent = new TracePointSnapshotEvent(
-          this.context.rawProbe.id,
+          this.context.rawProbe.id.replace(`${this.context.rawProbe.action}:`, ''),
           this.context.rawProbe.client,
           this.context.rawProbe.remoteFilename || this.context.rawProbe.fileName,
           convertedFrames && convertedFrames[0] ? convertedFrames[0].methodName : '',


### PR DESCRIPTION
Remove probe action prefix on log and trace point snapshot ids